### PR TITLE
Fix: Imported the correct onMounted const

### DIFF
--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -1,6 +1,6 @@
 <script>
 import {useToast} from "primevue/usetoast";
-import {computed, ref} from "vue";
+import { computed, onMounted, ref } from "vue";
 import {useRoute, useRouter} from "vue-router";
 import {createSite, getActiveCurrencies, getSite, updateSite} from "../api";
 import useStore from "../composition/useStore";


### PR DESCRIPTION
Issue: Currently the basic setup of this example is not loading correctly for sub pages.
The issue is a missing import of `onMounted`.
So this PR just adds the correct import so that the basic project is working.